### PR TITLE
feat: update visibility filtering with reversed -p flag behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,10 +31,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	onlyPublicRepository := flag.Bool("p", false, "Set to true to only list public repositories")
+	allowPrivate := flag.Bool("p", false, "Include private repositories in the list")
+	allowPrivateAlias := flag.Bool("private", false, "Include private repositories in the list")
+	includeOrgRepos := flag.Bool("A", false, "Include repositories from organizations you're a member of")
+	includeOrgReposAlias := flag.Bool("all", false, "Include repositories from organizations you're a member of")
 
 	flag.Parse()
-	repoList, err := repos.GetRepos(token, repos.RepoOptions{NumberOfResults: 20}, *onlyPublicRepository)
+	
+	// Use either flag for allowPrivate
+	showPrivate := *allowPrivate || *allowPrivateAlias
+	// Use either flag for includeOrgRepos
+	showOrgRepos := *includeOrgRepos || *includeOrgReposAlias
+	
+	repoList, err := repos.GetRepos(token, repos.RepoOptions{NumberOfResults: 20}, showPrivate, showOrgRepos)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/repos/repos.go
+++ b/repos/repos.go
@@ -13,7 +13,7 @@ type RepoOptions struct {
 	NumberOfResults int
 }
 
-func GetRepos(githubAccessToken string, repoOpts RepoOptions, publicOnly bool) ([]*github.Repository, error) {
+func GetRepos(githubAccessToken string, repoOpts RepoOptions, allowPrivate bool, includeOrgRepos bool) ([]*github.Repository, error) {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: githubAccessToken},
@@ -21,14 +21,21 @@ func GetRepos(githubAccessToken string, repoOpts RepoOptions, publicOnly bool) (
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
 
+	// Default affiliation is owner only
+	affiliation := "owner"
+	if includeOrgRepos {
+		affiliation = "owner,organization_member"
+	}
+
 	opts := &github.RepositoryListOptions{
-		Affiliation: "owner,organization_member",
+		Affiliation: affiliation,
 		Sort:        "updated",
 		Direction:   "desc",
 		ListOptions: github.ListOptions{Page: 1, PerPage: repoOpts.NumberOfResults},
 	}
 
-	if publicOnly {
+	// Default behavior is public repos only, unless allowPrivate is true
+	if !allowPrivate {
 		opts.Visibility = "public"
 	}
 


### PR DESCRIPTION
Addresses issue #6 by updating repository visibility filtering behavior.

## Summary
- **Default behavior:** Now shows only user's own public repositories
- **Reversed -p flag:** Changed from "public only" to "include private repositories"
- **Added --private flag:** Alias for -p flag
- **Added -A/--all flags:** Include organization repositories
- **Flexible combinations:** Flags can be combined for different filtering options

## Usage Examples
```bash
repo                    # Your own public repos only
repo -p                 # Your own repos (public + private)
repo -A                 # Your repos + org repos (all public)
repo -p -A              # All repos (yours + orgs, public + private)
```

Resolves #6

Generated with [Claude Code](https://claude.ai/code)